### PR TITLE
Pass previous actions to the model

### DIFF
--- a/cluster/train_cluster.sh
+++ b/cluster/train_cluster.sh
@@ -2,7 +2,7 @@
 #SBATCH -n 1
 #SBATCH --cpus-per-task=8
 #SBATCH --gpus=rtx_4090:4
-#SBATCH --time=18:00:00
+#SBATCH --time=12:00:00
 #SBATCH --mem-per-cpu=4048
 #SBATCH --mail-type=END
 #SBATCH --mail-user=name@mail

--- a/cluster/train_cluster.sh
+++ b/cluster/train_cluster.sh
@@ -23,7 +23,7 @@ conda activate $CONDA_ENV
 
 # Set environment variables and run training
 export DATASET_PATH=/cluster/home/spiasecki/terra/data/
-export DATASET_SIZE=200
+export DATASET_SIZE=500
 
 # Add the terra package to the Python path
 export PYTHONPATH=$PYTHONPATH:/cluster/home/lterenzi/terra_jax

--- a/eval_ppo.py
+++ b/eval_ppo.py
@@ -33,6 +33,7 @@ def rollout(
     env,
     env_params,
     train_state: TrainState,
+    prev_actions: jax.Array,
     config,
 ) -> RolloutStats:
     num_envs = config.num_envs_per_device
@@ -49,7 +50,7 @@ def rollout(
         rng, _rng_step, _rng_model = jax.random.split(rng, 3)
 
         action, _, _, _ = select_action_ppo(
-            train_state, timestep.observation, _rng_model, config
+            train_state, timestep.observation, prev_actions, _rng_model, config
         )
         _rng_step = jax.random.split(_rng_step, num_envs)
         action_env = wrap_action(action, env.batch_cfg.action_type)

--- a/train.py
+++ b/train.py
@@ -52,7 +52,7 @@ class TrainConfig:
     clip_action_maps = True  # clips the action maps to [-1, 1]
     local_map_normalization_bounds = [-16, 16]
     loaded_max = 100
-    num_rollouts_eval = 600  # max length of an episode in Terra for eval (for training it is in Terra's curriculum)
+    num_rollouts_eval = 400  # max length of an episode in Terra for eval (for training it is in Terra's curriculum)
 
     def __post_init__(self):
         self.num_devices = (

--- a/train.py
+++ b/train.py
@@ -480,6 +480,7 @@ def make_train(
                     env,
                     env_params_single,
                     train_state,
+                    prev_actions,
                     config,
                 )
 

--- a/train.py
+++ b/train.py
@@ -448,7 +448,7 @@ def make_train(
             # Use data from the first device for stats and eval
             loss_info_single = unreplicate(loss_info)
             runner_state_single = unreplicate(runner_state)
-            _, train_state, timestep = runner_state_single[:3]
+            _, train_state, timestep, prev_actions = runner_state_single[:4]
             env_params_single = timestep.env_cfg
 
             if i % config.log_train_interval == 0:

--- a/train.py
+++ b/train.py
@@ -476,8 +476,8 @@ def make_train(
                 n = config.num_envs_per_device * eval_stats.length
                 avg_positive_episode_length = jnp.where(
                     eval_stats.positive_terminations > 0,
-                    eval_stats.successful_episode_steps / eval_stats.positive_terminations,
-                    jnp.zeros_like(eval_stats.successful_episode_steps)
+                    eval_stats.positive_terminations_steps / eval_stats.positive_terminations,
+                    jnp.zeros_like(eval_stats.positive_terminations_steps)
                 )
                 loss_info_single.update(
                     {

--- a/utils/models.py
+++ b/utils/models.py
@@ -211,15 +211,15 @@ class AtariCNN(nn.Module):
 
     @nn.compact
     def __call__(self, x):
-        x = nn.Conv(features=8, kernel_size=(8, 8), strides=(4, 4))(x)
+        x = nn.Conv(features=16, kernel_size=(8, 8), strides=(4, 4))(x)
         x = nn.relu(x)
-        x = nn.Conv(features=16, kernel_size=(4, 4), strides=(2, 2))(x)
+        x = nn.Conv(features=32, kernel_size=(4, 4), strides=(2, 2))(x)
         x = nn.relu(x)
-        x = nn.Conv(features=16, kernel_size=(3, 3), strides=(1, 1))(x)
+        x = nn.Conv(features=32, kernel_size=(3, 3), strides=(1, 1))(x)
         x = nn.relu(x)
         x = x.reshape((x.shape[0], -1))
 
-        x = nn.Dense(features=64)(x)
+        x = nn.Dense(features=128)(x)
         x = nn.relu(x)
         x = nn.Dense(features=32)(x)
         return x

--- a/utils/models.py
+++ b/utils/models.py
@@ -28,6 +28,7 @@ def get_model_ready(rng, config, env: TerraEnvBatch, speed=False):
     )
     jax.debug.print("map normalization min max = {x}", x=map_min_max)
     model = SimplifiedCoupledCategoricalNet(
+        num_prev_actions=config["num_prev_actions"],
         num_embeddings_agent=num_embeddings_agent,
         map_min_max=map_min_max,
         local_map_min_max=tuple(config["local_map_normalization_bounds"]),

--- a/utils/utils_ppo.py
+++ b/utils/utils_ppo.py
@@ -10,7 +10,7 @@ def clip_action_maps_in_obs(obs):
     return obs
 
 
-def obs_to_model_input(obs, train_cfg):
+def obs_to_model_input(obs, prev_actions, train_cfg):
     # Feature engineering
     if train_cfg.clip_action_maps:
         obs = clip_action_maps_in_obs(obs)
@@ -28,6 +28,7 @@ def obs_to_model_input(obs, train_cfg):
         obs["traversability_mask"],
         obs["dig_map"],
         obs["dumpability_mask"],
+        prev_actions,
     ]
     return obs
 
@@ -45,11 +46,12 @@ def policy(
 def select_action_ppo(
     train_state,
     obs: jnp.ndarray,
+    prev_actions: jnp.ndarray,
     rng: jax.random.PRNGKey,
     config,
 ):
     # Prepare policy input from Terra State
-    obs = obs_to_model_input(obs, config)
+    obs = obs_to_model_input(obs, prev_actions, config)
 
     value, pi = policy(train_state.apply_fn, train_state.params, obs)
     action = pi.sample(seed=rng)


### PR DESCRIPTION
This PR adds another module to the network called `PreviousActionsNet`. It takes 5 (currently, adaptable parameter) previous actions and passes them to both the actor and critic.

The idea is: this should reduce the amount of times that the policy gets stuck and keeps switching between two actions over and over (look at video for explanation). It also could encourage exploration and speed up training.

https://github.com/user-attachments/assets/7cb48421-bb97-4c7d-9fcd-8627d7f6eca1


*TESTS IN PROGRESS*

