### PR TITLE
Introduce wandb sweeps over rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,45 @@ DATASET_PATH=/path/to/dataset DATASET_SIZE=<num_maps_per_type> python train.py -
 ```
 and collect your weights in the `checkpoints/` folder.
 
+## Sweep
+
+You can run a hyperparameter sweep over reward settings using [Weights & Biases Sweeps](https://docs.wandb.ai/guides/sweeps). This allows you to efficiently grid search or random search over reward parameters and compare results.
+
+### 1. Define the Sweep
+
+The sweep configuration is defined in `sweep.py`. It includes a grid over reward parameters such as `existence`, `collision_move`, `move`, etc. The sweep uses the `TrainConfigSweep` dataclass, which extends the standard training config with sweepable reward parameters.
+
+### 2. Create the Sweep
+
+To create a new sweep on wandb, run:
+```bash
+python sweep.py create
+```
+This will print a sweep ID (e.g., `abc123xy`). Copy this ID for the next step.
+
+### 3. Launch Agents
+
+You can launch multiple agents (workers) to run experiments in parallel. Each agent will pick up a different configuration from the sweep and start a training run.
+
+To launch an agent, run:
+```bash
+wandb agent <SWEEP_ID>
+```
+You can run this command multiple times (e.g., in different terminals, or as background jobs in a cluster script) to parallelize the sweep.
+
+#### Example: Running Multiple Agents in a Cluster Script
+
+If you are using a cluster, you can use the provided `sweep_cluster.sh` script. Make sure to set the `SWEEP_ID` variable to your sweep ID:
+```bash
+# In sweep_cluster.sh
+SWEEP_ID=<YOUR_SWEEP_ID>
+wandb agent $SWEEP_ID &
+wandb agent $SWEEP_ID &
+wandb agent $SWEEP_ID &
+wandb agent $SWEEP_ID &
+wait
+```
+
 ## Eval
 Evaluate your checkpoint with standard metrics using
 ```

--- a/cluster/sweep_cluster.sh
+++ b/cluster/sweep_cluster.sh
@@ -26,10 +26,10 @@ cd /cluster/home/spiasecki/terra-baselines
 # Create the sweep and capture the sweep ID
 SWEEP_ID=$(python sweep.py create | grep 'Create sweep with ID:' | awk '{print $5}')
 
-# Run two agents in parallel
-wandb agent $SWEEP_ID &  # Agent 1
-wandb agent $SWEEP_ID &  # Agent 2
-wandb agent $SWEEP_ID &  # Agent 3
-wandb agent $SWEEP_ID &  # Agent 4
+# Run agents in parallel
+wandb agent terra-sp-thesis/sweep/$SWEEP_ID &  # Agent 1
+wandb agent terra-sp-thesis/sweep/$SWEEP_ID &  # Agent 2
+wandb agent terra-sp-thesis/sweep/$SWEEP_ID &  # Agent 3
+wandb agent terra-sp-thesis/sweep/$SWEEP_ID &  # Agent 4
 
 wait

--- a/cluster/sweep_cluster.sh
+++ b/cluster/sweep_cluster.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#SBATCH -n 1
+#SBATCH --cpus-per-task=8
+#SBATCH --gpus=rtx_4090:8
+#SBATCH --time=12:00:00
+#SBATCH --mem-per-cpu=8G
+#SBATCH --mail-type=END
+#SBATCH --mail-user=name@mail
+#SBATCH --job-name="sweep-$(date +"%Y-%m-%dT%H:%M")"
+#SBATCH --output=%j_sweep.out
+
+module load eth_proxy
+module load stack/2024-06 cuda/12.1.1
+
+CONDA_ROOT=/cluster/home/spiasecki/miniconda3
+CONDA_ENV=terra
+
+eval "$($CONDA_ROOT/bin/conda shell.bash hook)"
+conda activate $CONDA_ENV
+
+export DATASET_PATH=/cluster/home/spiasecki/terra/data/
+export DATASET_SIZE=1000
+
+cd /cluster/home/spiasecki/terra-baselines
+
+# Create the sweep and capture the sweep ID
+SWEEP_ID=$(python -c "import sweep; print(sweep.create_sweep_and_return_id())")
+
+# Run two agents in parallel
+wandb agent $SWEEP_ID &  # Agent 1
+wandb agent $SWEEP_ID &  # Agent 2
+wandb agent $SWEEP_ID &  # Agent 3
+wandb agent $SWEEP_ID &  # Agent 4
+
+wait

--- a/cluster/sweep_cluster.sh
+++ b/cluster/sweep_cluster.sh
@@ -2,7 +2,7 @@
 #SBATCH -n 1
 #SBATCH --cpus-per-task=8
 #SBATCH --gpus=rtx_4090:8
-#SBATCH --time=128:00:00
+#SBATCH --time=120:00:00
 #SBATCH --mem-per-cpu=8G
 #SBATCH --mail-type=END
 #SBATCH --mail-user=name@mail

--- a/cluster/sweep_cluster.sh
+++ b/cluster/sweep_cluster.sh
@@ -2,7 +2,7 @@
 #SBATCH -n 1
 #SBATCH --cpus-per-task=8
 #SBATCH --gpus=rtx_4090:8
-#SBATCH --time=12:00:00
+#SBATCH --time=24:00:00
 #SBATCH --mem-per-cpu=8G
 #SBATCH --mail-type=END
 #SBATCH --mail-user=name@mail

--- a/cluster/sweep_cluster.sh
+++ b/cluster/sweep_cluster.sh
@@ -24,7 +24,7 @@ export DATASET_SIZE=1000
 cd /cluster/home/spiasecki/terra-baselines
 
 # Create the sweep and capture the sweep ID
-SWEEP_ID=$(python -c "import sweep; print(sweep.create_sweep_and_return_id())")
+SWEEP_ID=$(python sweep.py create)
 
 # Run two agents in parallel
 wandb agent $SWEEP_ID &  # Agent 1

--- a/cluster/sweep_cluster.sh
+++ b/cluster/sweep_cluster.sh
@@ -2,7 +2,7 @@
 #SBATCH -n 1
 #SBATCH --cpus-per-task=8
 #SBATCH --gpus=rtx_4090:8
-#SBATCH --time=24:00:00
+#SBATCH --time=128:00:00
 #SBATCH --mem-per-cpu=8G
 #SBATCH --mail-type=END
 #SBATCH --mail-user=name@mail
@@ -29,7 +29,5 @@ SWEEP_ID=$(python sweep.py create | grep 'Create sweep with ID:' | awk '{print $
 # Run agents in parallel
 wandb agent terra-sp-thesis/sweep/$SWEEP_ID &  # Agent 1
 wandb agent terra-sp-thesis/sweep/$SWEEP_ID &  # Agent 2
-wandb agent terra-sp-thesis/sweep/$SWEEP_ID &  # Agent 3
-wandb agent terra-sp-thesis/sweep/$SWEEP_ID &  # Agent 4
 
 wait

--- a/cluster/sweep_cluster.sh
+++ b/cluster/sweep_cluster.sh
@@ -24,7 +24,7 @@ export DATASET_SIZE=1000
 cd /cluster/home/spiasecki/terra-baselines
 
 # Create the sweep and capture the sweep ID
-SWEEP_ID=$(python sweep.py create)
+SWEEP_ID=$(python sweep.py create | grep 'Create sweep with ID:' | awk '{print $5}')
 
 # Run two agents in parallel
 wandb agent $SWEEP_ID &  # Agent 1

--- a/sweep.py
+++ b/sweep.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
                 "terminal": {"values": [10.0, 150.0]},
             }
         }
-        sweep_id = wandb.sweep(sweep_config, project="terra-sp-thesis")
+        sweep_id = wandb.sweep(sweep_config, project="sweep")
     else:
         # Called by wandb agent
         sweep_train()

--- a/sweep.py
+++ b/sweep.py
@@ -107,6 +107,10 @@ def sweep_train():
 if __name__ == "__main__":
     sweep_config = {
         "method": "grid",
+        "metric": {
+            "name": "eval/rewards",
+            "goal": "maximize",
+        },
         "parameters": {
             "existence": {"values": [-0.1, 0.0]},
             "collision_move": {"values": [-0.5, 0.0]},

--- a/sweep.py
+++ b/sweep.py
@@ -93,8 +93,8 @@ if __name__ == "__main__":
                 "wheel_turn": {"values": [-0.2, 0.0]},
                 "dig_wrong": {"values": [-1.0, 0.0]},
                 "dump_wrong": {"values": [-1.0, 0.0]},
-                "dig_correct": {"values": [0.0, 5.0]},
-                "dump_correct": {"values": [0.0, 10.0]},
+                "dig_correct": {"values": [1.0, 5.0]},
+                "dump_correct": {"values": [1.0, 10.0]},
                 "terminal": {"values": [10.0, 150.0]},
             }
         }

--- a/sweep.py
+++ b/sweep.py
@@ -17,13 +17,10 @@ class TrainConfigSweep(TrainConfig):
     existence: float = -0.1
     collision_move: float = -0.1
     move: float = -0.05
-    collision_turn: float = -0.1
     cabin_turn: float = -0.01
     wheel_turn: float = -0.01
     dig_wrong: float = -0.3
     dump_wrong: float = -0.3
-    dump_no_dump_area: float = -3.0
-    dump_close_to_dug_area: float = -0.15
     dig_correct: float = 3.0
     dump_correct: float = 3.0
     terminal: float = 100.0
@@ -40,13 +37,10 @@ def make_states(config: TrainConfigSweep):
             existence=config.existence,
             collision_move=config.collision_move,
             move=config.move,
-            collision_turn=config.collision_turn,
             cabin_turn=config.cabin_turn,
             wheel_turn=config.wheel_turn,
             dig_wrong=config.dig_wrong,
             dump_wrong=config.dump_wrong,
-            dump_no_dump_area=config.dump_no_dump_area,
-            dump_close_to_dug_area=config.dump_close_to_dug_area,
             dig_correct=config.dig_correct,
             dump_correct=config.dump_correct,
             terminal=config.terminal,
@@ -125,5 +119,21 @@ if __name__ == "__main__":
     )
     args, _ = parser.parse_known_args()
 
+    sweep_config = {
+        "method": "grid",
+        "parameters": {
+            "existence": {"values": [-0.1, 0.0]},
+            "collision_move": {"values": [-0.5, 0.0]},
+            "move": {"values": [-0.2, 0.0]},
+            "cabin_turn": {"values": [-0.2, 0.0]},
+            "wheel_turn": {"values": [-0.2, 0.0]},
+            "dig_wrong": {"values": [-1.0, 0.0]},
+            "dump_wrong": {"values": [-1.0, 0.0]},
+            "dig_correct": {"values": [0.0, 5.0]},
+            "dump_correct": {"values": [0.0, 10.0]},
+            "terminal": {"values": [10.0, 150.0]},
+        }
+    }
+
     name = f"{args.name}-{args.machine}-{DT}"
-    train(TrainConfig(name=name, num_devices=args.num_devices))
+    train(TrainConfigSweep(name=name, num_devices=args.num_devices))

--- a/sweep.py
+++ b/sweep.py
@@ -34,21 +34,22 @@ def make_states(config: TrainConfigSweep):
     num_envs_per_device = config.num_envs_per_device
 
     # Replace the rewards witht the sweep values
+    env_params = EnvConfig()
     env_params = env_params._replace(
         rewards=env_params.rewards._replace(
-            existence=config.reward_existence,
-            collision_move=config.reward_collision_move,
-            move=config.reward_move,
-            collision_turn=config.reward_collision_turn,
-            cabin_turn=config.reward_cabin_turn,
-            wheel_turn=config.reward_wheel_turn,
-            dig_wrong=config.reward_dig_wrong,
-            dump_wrong=config.reward_dump_wrong,
-            dump_no_dump_area=config.reward_dump_no_dump_area,
-            dump_close_to_dug_area=config.reward_dump_close_to_dug_area,
-            dig_correct=config.reward_dig_correct,
-            dump_correct=config.reward_dump_correct,
-            terminal=config.reward_terminal,
+            existence=config.existence,
+            collision_move=config.collision_move,
+            move=config.move,
+            collision_turn=config.collision_turn,
+            cabin_turn=config.cabin_turn,
+            wheel_turn=config.wheel_turn,
+            dig_wrong=config.dig_wrong,
+            dump_wrong=config.dump_wrong,
+            dump_no_dump_area=config.dump_no_dump_area,
+            dump_close_to_dug_area=config.dump_close_to_dug_area,
+            dig_correct=config.dig_correct,
+            dump_correct=config.dump_correct,
+            terminal=config.terminal,
         )
     )
     env_params = jax.tree_map(

--- a/sweep.py
+++ b/sweep.py
@@ -14,6 +14,10 @@ from utils.models import get_model_ready
 
 @dataclass
 class TrainConfigSweep(TrainConfig):
+    # Training config
+    total_timesteps: int = 5_000_000
+
+    # Rewards
     existence: float = -0.1
     collision_move: float = -0.1
     move: float = -0.05

--- a/sweep.py
+++ b/sweep.py
@@ -11,7 +11,7 @@ from train import make_states, make_train, TrainConfig
 class TrainConfigSweep(TrainConfig):
     # Training config
     project: str = "sweep"
-    total_timesteps: int = 3_000_000
+    total_timesteps: int = 3_000_000_000
 
     # Rewards
     existence: float = -0.1

--- a/sweep.py
+++ b/sweep.py
@@ -10,7 +10,7 @@ from train import make_states, make_train, TrainConfig
 @dataclass
 class TrainConfigSweep(TrainConfig):
     # Training config
-    project: str = "sweep"
+    project: str = "terra-sp-thesis"
     total_timesteps: int = 3_000_000_000
 
     # Rewards
@@ -85,6 +85,7 @@ if __name__ == "__main__":
                 "goal": "maximize",
             },
             "parameters": {
+                "project": {"value": "terra-sp-thesis"},
                 "existence": {"values": [-0.1, 0.0]},
                 "collision_move": {"values": [-0.5, 0.0]},
                 "move": {"values": [-0.2, 0.0]},
@@ -97,7 +98,7 @@ if __name__ == "__main__":
                 "terminal": {"values": [10.0, 150.0]},
             }
         }
-        sweep_id = wandb.sweep(sweep_config, project="sweep")
+        sweep_id = wandb.sweep(sweep_config, project="terra-sp-thesis")
     else:
         # Called by wandb agent
         sweep_train()

--- a/sweep.py
+++ b/sweep.py
@@ -1,16 +1,10 @@
 import jax
-import jax.numpy as jnp
-import optax
 import time
 import wandb
 from dataclasses import asdict, dataclass
-from datetime import datetime
-from flax.training.train_state import TrainState
 
-from terra.env import TerraEnvBatch
 from terra.config import EnvConfig
 from train import make_states, make_train, TrainConfig
-from utils.models import get_model_ready
 
 @dataclass
 class TrainConfigSweep(TrainConfig):

--- a/sweep.py
+++ b/sweep.py
@@ -79,13 +79,13 @@ if __name__ == "__main__":
     # If called with "create" argument, create the sweep and print the ID
     if len(sys.argv) > 1 and sys.argv[1] == "create":
         sweep_config = {
+            "program": "train.py",
             "method": "grid",
             "metric": {
                 "name": "eval/rewards",
                 "goal": "maximize",
             },
             "parameters": {
-                "project": {"value": "terra-sp-thesis"},
                 "existence": {"values": [-0.1, 0.0]},
                 "collision_move": {"values": [-0.5, 0.0]},
                 "move": {"values": [-0.2, 0.0]},

--- a/sweep.py
+++ b/sweep.py
@@ -10,6 +10,7 @@ from train import make_states, make_train, TrainConfig
 @dataclass
 class TrainConfigSweep(TrainConfig):
     # Training config
+    project: str = "sweep"
     total_timesteps: int = 3_000_000
 
     # Rewards
@@ -96,7 +97,7 @@ if __name__ == "__main__":
                 "terminal": {"values": [10.0, 150.0]},
             }
         }
-        sweep_id = wandb.sweep(sweep_config, project="sweep")
+        sweep_id = wandb.sweep(sweep_config, project=TrainConfigSweep().project)
     else:
         # Called by wandb agent
         sweep_train()

--- a/sweep.py
+++ b/sweep.py
@@ -101,31 +101,6 @@ def sweep_train():
     train(train_config)
 
 if __name__ == "__main__":
-    DT = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-    import argparse
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-n",
-        "--name",
-        type=str,
-        default="experiment",
-    )
-    parser.add_argument(
-        "-m",
-        "--machine",
-        type=str,
-        default="local",
-    )
-    parser.add_argument(
-        "-d",
-        "--num_devices",
-        type=int,
-        default=0,
-        help="Number of devices to use. If 0, uses all available devices.",
-    )
-    args, _ = parser.parse_known_args()
-
     sweep_config = {
         "method": "grid",
         "parameters": {

--- a/sweep.py
+++ b/sweep.py
@@ -15,7 +15,7 @@ from utils.models import get_model_ready
 @dataclass
 class TrainConfigSweep(TrainConfig):
     # Training config
-    total_timesteps: int = 5_000_000
+    total_timesteps: int = 3_000_000
 
     # Rewards
     existence: float = -0.1

--- a/sweep.py
+++ b/sweep.py
@@ -1,5 +1,6 @@
 import jax
 import time
+import sys
 import wandb
 from dataclasses import asdict, dataclass
 
@@ -74,25 +75,28 @@ def sweep_train():
     train(train_config)
 
 if __name__ == "__main__":
-    sweep_config = {
-        "method": "grid",
-        "metric": {
-            "name": "eval/rewards",
-            "goal": "maximize",
-        },
-        "parameters": {
-            "existence": {"values": [-0.1, 0.0]},
-            "collision_move": {"values": [-0.5, 0.0]},
-            "move": {"values": [-0.2, 0.0]},
-            "cabin_turn": {"values": [-0.2, 0.0]},
-            "wheel_turn": {"values": [-0.2, 0.0]},
-            "dig_wrong": {"values": [-1.0, 0.0]},
-            "dump_wrong": {"values": [-1.0, 0.0]},
-            "dig_correct": {"values": [0.0, 5.0]},
-            "dump_correct": {"values": [0.0, 10.0]},
-            "terminal": {"values": [10.0, 150.0]},
+    # If called with "create" argument, create the sweep and print the ID
+    if len(sys.argv) > 1 and sys.argv[1] == "create":
+        sweep_config = {
+            "method": "grid",
+            "metric": {
+                "name": "eval/rewards",
+                "goal": "maximize",
+            },
+            "parameters": {
+                "existence": {"values": [-0.1, 0.0]},
+                "collision_move": {"values": [-0.5, 0.0]},
+                "move": {"values": [-0.2, 0.0]},
+                "cabin_turn": {"values": [-0.2, 0.0]},
+                "wheel_turn": {"values": [-0.2, 0.0]},
+                "dig_wrong": {"values": [-1.0, 0.0]},
+                "dump_wrong": {"values": [-1.0, 0.0]},
+                "dig_correct": {"values": [0.0, 5.0]},
+                "dump_correct": {"values": [0.0, 10.0]},
+                "terminal": {"values": [10.0, 150.0]},
+            }
         }
-    }
-
-    sweep_id = wandb.sweep(sweep_config, project="terra-sp-thesis")
-    wandb.agent(sweep_id, function=sweep_train)
+        sweep_id = wandb.sweep(sweep_config, project="terra-sp-thesis")
+    else:
+        # Called by wandb agent
+        sweep_train()

--- a/sweep.py
+++ b/sweep.py
@@ -11,7 +11,7 @@ from train import make_states, make_train, TrainConfig
 class TrainConfigSweep(TrainConfig):
     # Training config
     project: str = "sweep"
-    total_timesteps: int = 3_000_000_000
+    total_timesteps: int = 2_000_000_000
 
     # Rewards
     existence: float = -0.1

--- a/sweep.py
+++ b/sweep.py
@@ -10,7 +10,7 @@ from train import make_states, make_train, TrainConfig
 @dataclass
 class TrainConfigSweep(TrainConfig):
     # Training config
-    project: str = "terra-sp-thesis"
+    project: str = "sweep"
     total_timesteps: int = 3_000_000_000
 
     # Rewards
@@ -98,7 +98,7 @@ if __name__ == "__main__":
                 "terminal": {"values": [10.0, 150.0]},
             }
         }
-        sweep_id = wandb.sweep(sweep_config, project="terra-sp-thesis")
+        sweep_id = wandb.sweep(sweep_config, project="sweep")
     else:
         # Called by wandb agent
         sweep_train()

--- a/sweep.py
+++ b/sweep.py
@@ -1,0 +1,95 @@
+import jax
+import jax.numpy as jnp
+import optax
+import time
+import wandb
+from dataclasses import asdict
+from datetime import datetime
+from flax.training.train_state import TrainState
+
+from terra.env import TerraEnvBatch
+from terra.config import EnvConfig
+from train import make_train, TrainConfig
+from utils.models import get_model_ready
+
+def make_states(config: TrainConfig):
+    env = TerraEnvBatch()
+    num_devices = config.num_devices
+    num_envs_per_device = config.num_envs_per_device
+
+    env_params = EnvConfig()
+    env_params = jax.tree_map(
+        lambda x: jnp.array(x)[None, None]
+        .repeat(num_devices, 0)
+        .repeat(num_envs_per_device, 1),
+        env_params,
+    )
+    print(f"{env_params.tile_size.shape=}")
+
+    rng = jax.random.PRNGKey(config.seed)
+    rng, _rng = jax.random.split(rng)
+
+    network, network_params = get_model_ready(_rng, config, env)
+    tx = optax.chain(
+        optax.clip_by_global_norm(config.max_grad_norm),
+        optax.adam(learning_rate=config.lr, eps=1e-5),
+    )
+    train_state = TrainState.create(
+        apply_fn=network.apply, params=network_params, tx=tx
+    )
+
+    return rng, env, env_params, train_state
+
+def train(config: TrainConfig):
+    run = wandb.init(
+        entity="terra-sp-thesis",
+        project=config.project,
+        group=config.group,
+        name=config.name,
+        config=asdict(config),
+        save_code=True,
+    )
+    rng, env, env_params, train_state = make_states(config)
+    train_fn = make_train(env, env_params, config)
+
+    print("Training...")
+    try:  # Try block starts here
+        t = time.time()
+        train_info = jax.block_until_ready(train_fn(rng, train_state))
+        elapsed_time = time.time() - t
+        print(f"Done in {elapsed_time:.2f}s")
+    except KeyboardInterrupt:  # Catch Ctrl+C
+        print("Training interrupted. Finalizing...")
+    finally:  # Ensure wandb.finish() is called
+        run.finish()
+        print("wandb session finished.")
+
+
+if __name__ == "__main__":
+    DT = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-n",
+        "--name",
+        type=str,
+        default="experiment",
+    )
+    parser.add_argument(
+        "-m",
+        "--machine",
+        type=str,
+        default="local",
+    )
+    parser.add_argument(
+        "-d",
+        "--num_devices",
+        type=int,
+        default=0,
+        help="Number of devices to use. If 0, uses all available devices.",
+    )
+    args, _ = parser.parse_known_args()
+
+    name = f"{args.name}-{args.machine}-{DT}"
+    train(TrainConfig(name=name, num_devices=args.num_devices))

--- a/sweep.py
+++ b/sweep.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
                 "terminal": {"values": [10.0, 150.0]},
             }
         }
-        sweep_id = wandb.sweep(sweep_config, project=TrainConfigSweep().project)
+        sweep_id = wandb.sweep(sweep_config, project="sweep")
     else:
         # Called by wandb agent
         sweep_train()

--- a/sweep.py
+++ b/sweep.py
@@ -92,6 +92,13 @@ def train(config: TrainConfigSweep):
         run.finish()
         print("wandb session finished.")
 
+def sweep_train():
+    config = wandb.config
+    if "name" not in config:
+        config["name"] = f"sweep-{wandb.run.id}"
+    # Convert wandb.config to TrainConfigSweep
+    train_config = TrainConfigSweep(**dict(config))
+    train(train_config)
 
 if __name__ == "__main__":
     DT = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
@@ -135,5 +142,5 @@ if __name__ == "__main__":
         }
     }
 
-    name = f"{args.name}-{args.machine}-{DT}"
-    train(TrainConfigSweep(name=name, num_devices=args.num_devices))
+    sweep_id = wandb.sweep(sweep_config, project="terra-sp-thesis")
+    wandb.agent(sweep_id, function=sweep_train)

--- a/train.py
+++ b/train.py
@@ -75,12 +75,11 @@ class TrainConfig:
         return getattr(self, key)
 
 
-def make_states(config: TrainConfig):
+def make_states(config: TrainConfig, env_params: EnvConfig = EnvConfig()):
     env = TerraEnvBatch()
     num_devices = config.num_devices
     num_envs_per_device = config.num_envs_per_device
 
-    env_params = EnvConfig()
     env_params = jax.tree_map(
         lambda x: jnp.array(x)[None, None]
         .repeat(num_devices, 0)


### PR DESCRIPTION
This introduces wandb sweeps which can be done over PPO parameters but also more importantly over rewards. The parameters we perform the sweep on are defined in `sweep_config`. Any currently non-present parameters can be added but then `TrainConfigSweep` has to be extended and they have to be passed to the `EnvConfig` in `train()` function.

**TEST IN PROGRESS**