### PR TITLE
Add delayed residual map encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ python train_mixed.py --config excavator_truck --transport_relocate_mult 2.0
 
 # Use preset but override agent types
 python train_mixed.py --config solo_excavator --agent_types "(0,2)"
+
+# Use the delayed-downsampling residual encoder for 64x64 global maps
+python train_mixed.py --config solo_excavator --map_encoder resnet_delayed
 ```
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,73 @@
+import unittest
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+from terra.config import BatchConfig, MapsDimsConfig
+
+from utils.models import DelayedDownsampleResNet, MapsNet, get_model_ready
+
+
+class DelayedDownsampleResNetTest(unittest.TestCase):
+    def test_output_shape_and_backward_pass(self):
+        model = DelayedDownsampleResNet()
+        inputs = jax.random.normal(
+            jax.random.PRNGKey(1), (2, 64, 64, 7), dtype=jnp.float32
+        )
+        params = model.init(jax.random.PRNGKey(0), inputs)
+
+        output = model.apply(params, inputs)
+        self.assertEqual(output.shape, (2, 128))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(output))))
+
+        loss, gradients = jax.jit(
+            jax.value_and_grad(
+                lambda variables: jnp.mean(model.apply(variables, inputs) ** 2)
+            )
+        )(params)
+        self.assertTrue(bool(jnp.isfinite(loss)))
+        self.assertTrue(
+            all(bool(jnp.all(jnp.isfinite(x))) for x in jax.tree.leaves(gradients))
+        )
+
+    def test_maps_net_selects_residual_encoder(self):
+        model = MapsNet(map_min_max=(-1, 1), encoder_type="resnet_delayed")
+        maps = [jnp.zeros((2, 64, 64), dtype=jnp.float32) for _ in range(7)]
+        params = model.init(jax.random.PRNGKey(0), maps)
+
+        output = model.apply(params, maps)
+        self.assertEqual(output.shape, (2, 128))
+
+    def test_maps_net_keeps_atari_encoder_as_default(self):
+        model = MapsNet(map_min_max=(-1, 1))
+        maps = [jnp.zeros((2, 64, 64), dtype=jnp.float32) for _ in range(7)]
+        params = model.init(jax.random.PRNGKey(0), maps)
+
+        output = model.apply(params, maps)
+        self.assertEqual(output.shape, (2, 32))
+
+    def test_full_policy_initializes_with_residual_encoder(self):
+        class Config(dict):
+            __getattr__ = dict.__getitem__
+
+        config = Config(
+            clip_action_maps=False,
+            loaded_max=6,
+            local_map_normalization_bounds=(-1, 1),
+            map_encoder="resnet_delayed",
+            maps_net_normalization_bounds=(-1, 1),
+            model_core="mlp",
+            model_size="base",
+            num_prev_actions=5,
+        )
+        env = SimpleNamespace(
+            batch_cfg=BatchConfig(maps_dims=MapsDimsConfig(maps_edge_length=64))
+        )
+
+        model, params = get_model_ready(jax.random.PRNGKey(0), config, env)
+        self.assertEqual(model.map_encoder, "resnet_delayed")
+        self.assertGreater(sum(x.size for x in jax.tree.leaves(params)), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/train_mixed.py
+++ b/train_mixed.py
@@ -473,6 +473,7 @@ class MixedAgentTrainConfig:
     target_map_repeat: int = 0
     model_size: str = "base"
     model_core: str = "mlp"
+    map_encoder: str = "atari"
 
 
     def __post_init__(self):
@@ -767,6 +768,7 @@ def make_mixed_agent_states(config: MixedAgentTrainConfig, env_params: EnvConfig
     # Create the unified network with agent type features (now that num_prev_actions is set)
     print(f"🧠 Model size preset: {getattr(config, 'model_size', 'base')}", flush=True)
     print(f"🧠 Model core: {getattr(config, 'model_core', 'mlp')}", flush=True)
+    print(f"🧠 Map encoder: {getattr(config, 'map_encoder', 'atari')}", flush=True)
     print("⏱️  Initializing model...", flush=True)
     t_model_init = time.time()
     network, network_params = get_model_ready(_rng, config, env)
@@ -779,6 +781,7 @@ def make_mixed_agent_states(config: MixedAgentTrainConfig, env_params: EnvConfig
     print("🏗️ Architecture:", flush=True)
     print(f"   core: {model_core}", flush=True)
     print(f"   model_size: {getattr(config, 'model_size', 'base')}", flush=True)
+    print(f"   map_encoder: {getattr(config, 'map_encoder', 'atari')}", flush=True)
     if model_core == "transformer":
         max_agents = 4
         token_count = max_agents + 3  # agent tokens + actions/local/maps tokens
@@ -834,6 +837,7 @@ def _wandb_tags_for_config(config: MixedAgentTrainConfig) -> list[str]:
     )
 
     model_size = config.model_size if hasattr(config, "model_size") else "unknown"
+    map_encoder = getattr(config, "map_encoder", "atari")
 
     tags = [
         "mixed-agents",
@@ -842,6 +846,7 @@ def _wandb_tags_for_config(config: MixedAgentTrainConfig) -> list[str]:
         f"agents:{'-'.join(agent_type_names.get(int(t), str(t)) for t in agent_types)}",
         f"actions:{'-'.join(action_type_names.get(int(t), str(t)) for t in action_types)}",
         f"model-size:{_tag_value(model_size)}",
+        f"map-encoder:{_tag_value(map_encoder)}",
         f"dump-min-free-fraction:{_tag_value(dump_min_free_fraction)}",
         f"move-tiles:{_tag_value(env_defaults.agent.move_tiles)}",
         f"dig-radius-tiles:{_tag_value(env_defaults.agent.dig_radius_tiles)}",
@@ -1633,6 +1638,13 @@ if __name__ == "__main__":
         help="Core policy architecture. 'mlp' keeps current behavior; 'transformer' uses a lightweight token-mixer core.",
     )
     parser.add_argument(
+        "--map_encoder",
+        type=str,
+        default="atari",
+        choices=["atari", "resnet_delayed"],
+        help="Global-map encoder. 'resnet_delayed' preserves 64x64 detail before downsampling.",
+    )
+    parser.add_argument(
         "--agent_types", type=str, default=None,   # 0=excavator, 1=truck, 2=skidsteer
         help="Override agent types with a Python tuple, e.g. '(2,0,2,0)'. Overrides --config."
     )
@@ -1917,6 +1929,7 @@ if __name__ == "__main__":
         target_map_repeat=args.target_map_repeat,
         model_size=args.model_size,
         model_core=args.model_core,
+        map_encoder=args.map_encoder,
     )
     
     train_mixed_agents(config) 

--- a/utils/models.py
+++ b/utils/models.py
@@ -38,6 +38,7 @@ def get_model_ready(rng, config, env: TerraEnvBatch, speed=False):
         raise ValueError(
             f"Unsupported model_core='{model_core}'. Expected 'mlp' or 'transformer'."
         )
+    map_encoder = getattr(config, "map_encoder", "atari")
 
     model_kwargs = {}
     if model_size == "medium":
@@ -78,6 +79,7 @@ def get_model_ready(rng, config, env: TerraEnvBatch, speed=False):
         agent_types_max=2,  # Maximum agent type value (0=excavator, 1=truck, 2=skidsteer)
         action_type=env.batch_cfg.action_type,
         model_core=model_core,
+        map_encoder=map_encoder,
         **model_kwargs,
     )
 
@@ -354,6 +356,74 @@ class AtariCNN(nn.Module):
         return x
 
 
+class ResidualMapBlock(nn.Module):
+    """Two map convolutions with a projected skip connection when needed."""
+
+    features: int
+    strides: tuple[int, int] = (1, 1)
+
+    @nn.compact
+    def __call__(self, x):
+        residual = x
+        x = nn.Conv(
+            features=self.features,
+            kernel_size=(3, 3),
+            strides=self.strides,
+            padding="SAME",
+            use_bias=False,
+        )(x)
+        x = nn.LayerNorm()(x)
+        x = nn.relu(x)
+        x = nn.Conv(
+            features=self.features,
+            kernel_size=(3, 3),
+            padding="SAME",
+            use_bias=False,
+        )(x)
+        x = nn.LayerNorm()(x)
+
+        if residual.shape[-1] != self.features or self.strides != (1, 1):
+            residual = nn.Conv(
+                features=self.features,
+                kernel_size=(1, 1),
+                strides=self.strides,
+                padding="SAME",
+                use_bias=False,
+            )(residual)
+            residual = nn.LayerNorm()(residual)
+
+        return nn.relu(x + residual)
+
+
+class DelayedDownsampleResNet(nn.Module):
+    """Encode 64x64 maps before pooling them to a fixed 128-feature vector."""
+
+    @nn.compact
+    def __call__(self, x):
+        channels = (16, 32, 32)
+        x = nn.Conv(
+            features=channels[0],
+            kernel_size=(3, 3),
+            padding="SAME",
+            use_bias=False,
+        )(x)
+        x = nn.LayerNorm()(x)
+        x = nn.relu(x)
+
+        # Keep the first residual stage at full resolution; downsample only
+        # when entering the two later stages so narrow map details survive.
+        for stage, features in enumerate(channels):
+            for block in range(2):
+                strides = (2, 2) if stage > 0 and block == 0 else (1, 1)
+                x = ResidualMapBlock(features=features, strides=strides)(x)
+
+        x = jnp.concatenate(
+            (jnp.mean(x, axis=(1, 2)), jnp.max(x, axis=(1, 2))), axis=-1
+        )
+        x = nn.relu(nn.Dense(features=128)(x))
+        return nn.Dense(features=128)(x)
+
+
 @jax.jit
 def min_pool(x):
     pool_fn = partial(
@@ -394,9 +464,19 @@ class MapsNet(nn.Module):
     map_min_max: Sequence[int]
     cnn_channels: Sequence[int] = (16, 32, 32)
     cnn_dense_layers: Sequence[int] = (128, 32)
+    encoder_type: str = "atari"
 
     def setup(self) -> None:
-        self.cnn = AtariCNN(conv_channels=self.cnn_channels, dense_layers=self.cnn_dense_layers)
+        if self.encoder_type == "atari":
+            self.cnn = AtariCNN(
+                conv_channels=self.cnn_channels,
+                dense_layers=self.cnn_dense_layers,
+            )
+            return
+        if self.encoder_type == "resnet_delayed":
+            self.cnn = DelayedDownsampleResNet()
+            return
+        raise ValueError(f"Unknown map encoder: {self.encoder_type}")
 
     def __call__(self, obs: dict[str, Array]):
         """
@@ -528,6 +608,7 @@ class SimplifiedCoupledCategoricalNet(nn.Module):
     cnn_dense_layers: Sequence[int] = (128, 32)
     local_map_hidden_dim_layers_mlp: Sequence[int] = (256, 32)
     model_core: str = "mlp"  # "mlp" or "transformer"
+    map_encoder: str = "atari"
     transformer_model_dim: int = 128
     transformer_num_layers: int = 2
     transformer_num_heads: int = 4
@@ -564,6 +645,7 @@ class SimplifiedCoupledCategoricalNet(nn.Module):
             self.map_min_max,
             cnn_channels=self.cnn_channels,
             cnn_dense_layers=self.cnn_dense_layers,
+            encoder_type=self.map_encoder,
         )
 
         self.actions_net = PreviousActionsNet(


### PR DESCRIPTION
## Summary

- add the delayed-downsampling residual encoder for 64x64 global maps
- expose it as `--map_encoder resnet_delayed`
- keep the existing Atari encoder as the default for unchanged behavior
- log the selected encoder and add it to W&B tags

## Why

The previous residual-network prototype lived in a broad WIP PR that also changed action masking, checkpoint compatibility, actor/critic trunks, distillation, launchers, and experiment documentation. This PR extracts only the map-encoder feature onto `main` so the architecture is easy to review and use independently.

The residual path keeps its first stage at full map resolution, downsamples only when entering the two later stages, then combines global average and max pooling into a fixed 128-feature map representation.

## Impact

Existing commands and checkpoints continue to use the Atari encoder unless `map_encoder` was explicitly saved or `--map_encoder resnet_delayed` is passed. No Terra environment changes are required.

## Validation

- `python -m py_compile train_mixed.py utils/models.py tests/test_models.py`
- `python -m unittest discover -s tests -v`
  - jitted CPU residual forward/backward finiteness
  - residual and Atari output-shape checks
  - default Atari-path regression check
  - full 64x64 policy initialization (`320,169` parameters)
- `python train_mixed.py --help` exposes `--map_encoder {atari,resnet_delayed}`
- `git diff --check`

No PPO first-update or GPU smoke was launched for this cleanup PR. An independent Oracle browser review was attempted, but the signed-in page exposed no model selector, so it was not counted as a passed review gate.
